### PR TITLE
RUN-2219 RUN-2219 added useOnlyFreeCPUResources flag to queue

### DIFF
--- a/runai-crds.yaml
+++ b/runai-crds.yaml
@@ -250,5 +250,7 @@ spec:
                   type: array
                 swapEnabled:
                   type: boolean
+                useOnlyFreeCPUResources:
+                  type: boolean
               type: object
           type: object


### PR DESCRIPTION
to support cpu resource preemption via reclaim step on scheduler

related PR on runai-chart: https://github.com/run-ai/runai-chart/pull/47
related PR on scheduler: run-ai/runai-scheduler#219
related jira: https://runai.atlassian.net/browse/RUN-2219